### PR TITLE
Support litteral text for select options

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -1056,7 +1056,7 @@ XPATH;
     {
         $escapedValue = $this->xpathEscaper->escapeLiteral($value);
         // The value of an option is the normalized version of its text when it has no value attribute
-        $optionQuery = sprintf('.//option[@value = %s or (not(@value) and normalize-space(.) = %s)]', $escapedValue, $escapedValue);
+        $optionQuery = sprintf('.//option[@value = %s or normalize-space(.) = %s]', $escapedValue, $escapedValue);
         $option = $element->element('xpath', $optionQuery);
 
         if ($multiple || !$element->attribute('multiple')) {


### PR DESCRIPTION
By now, you cannot pass a select option label as an option.

This PR makes it possible to specify an option's text as selector.

PS : I don't get the meaning of `not(@value)`, so I removed it.
